### PR TITLE
Fix doc: swapped params at RegisterBehaviourBefore call

### DIFF
--- a/mod-making/player-behaviour.md
+++ b/mod-making/player-behaviour.md
@@ -132,7 +132,7 @@ foreach (var behaviour in existingBehaviours)
         var newBehaviour = new MyCoolPreCollisionBehaviour();
 
         // Register it to run before the X collision resolve
-        player.m_body.RegisterBehaviourBefore(behaviour, newBehaviour);
+        player.m_body.RegisterBehaviourBefore(newBehaviour, behaviour);
         break;
     }
 }


### PR DESCRIPTION
public bool RegisterBehaviourBefore(
      IBodyCompBehaviour behaviour,
      IBodyCompBehaviour beforeBehaviour)

The 2 params are swapped in the doc.